### PR TITLE
chore: split dependencies and add makefile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,2 @@
-# Database URL
 DATABASE_URL=sqlite:///./contractor.db
-
-# Default LaTeX engine: tectonic | xelatex
 LATEX_ENGINE=tectonic

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: install init-db
+
+# Install dependencies including runtime and development extras
+install:
+	poetry install -E runtime -E dev
+
+# Initialize the application's database
+init-db:
+	poetry run contractor init-db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{name = "You"}]
 
-dependencies = [
+# Core package has no hard runtime dependencies; they are provided via
+# optional "runtime" extras to keep the base install minimal.
+dependencies = []
+
+[project.optional-dependencies]
+# Dependencies required to run the application
+runtime = [
   "typer>=0.12.3",
   "rich>=13.7.1",
   "Jinja2>=3.1.4",
@@ -29,11 +35,14 @@ dependencies = [
   "pandas>=2.2.2",
   "openpyxl>=3.1.5",
   "watchdog>=4.0.2",
-  "PyPDF2>=3.0.1"
+  "PyPDF2>=3.0.1",
 ]
 
-[project.optional-dependencies]
-dev = ["pytest>=8.2.2", "ruff>=0.6.9"]
+# Tooling and test dependencies for development
+dev = [
+  "pytest>=8.2.2",
+  "ruff>=0.6.9",
+]
 
 [project.scripts]
 contractor = "contractor.cli:app"


### PR DESCRIPTION
## Summary
- split runtime and development extras in `pyproject.toml`
- provide example environment variables for database and LaTeX engine
- add Makefile with install and database initialization helpers

## Testing
- `make install` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest`
- `make init-db` *(fails: Command not found: contractor)*

------
https://chatgpt.com/codex/tasks/task_e_68affd9842508328a1d4b96287d2a5d0