### PR TITLE
Add contract tracking fields with Alembic setup

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+# Alembic 配置文件：用于设定数据库迁移的基本参数
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///contractor.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,56 @@
+"""配置 Alembic 迁移环境的脚本"""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from contractor.db import DATABASE_URL, engine
+from contractor.models import SQLModel
+
+# Alembic 配置对象，可访问 .ini 文件中的值
+config = context.config
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+# 解析配置文件以配置 Python 日志
+# 该行用于初始化日志器
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# 在此处添加模型的 MetaData 对象
+# 以支持自动生成迁移
+# 例如: from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """在离线模式下运行迁移"""
+    context.configure(url=DATABASE_URL, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """在在线模式下运行迁移"""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section) or {},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,25 @@
+## Alembic 迁移脚本模板
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma, n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# 迁移标识符，由 Alembic 使用
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+def upgrade() -> None:
+${upgrades if upgrades else "    pass"}
+
+def downgrade() -> None:
+${downgrades if downgrades else "    pass"}

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,60 @@
+# Alembic 初始迁移脚本
+"""初始迁移
+
+修订 ID: 0001_initial
+上一次修订:
+创建日期: 2024-01-01
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "party",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("country", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_party_name", "party", ["name"], unique=False)
+
+    op.create_table(
+        "contract",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("party_id", sa.Integer(), nullable=False),
+        sa.Column("currency", sa.String(), nullable=False, server_default="CNY"),
+        sa.Column("amount_minor", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("version", sa.String(), nullable=False, server_default="0.1.0"),
+        sa.Column("template_name", sa.String(), nullable=False, server_default="basic_zh"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("effective_date", sa.Date(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="draft"),
+        sa.Column("status_history", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("currency_rate", sa.Float(), nullable=False, server_default="1.0"),
+        sa.ForeignKeyConstraint(["party_id"], ["party.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "contractfile",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("contract_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["contract_id"], ["contract.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("contractfile")
+    op.drop_table("contract")
+    op.drop_index("ix_party_name", table_name="party")
+    op.drop_table("party")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ runtime = [
 dev = [
   "pytest>=8.2.2",
   "ruff>=0.6.9",
+  "alembic>=1.13.1",
 ]
 
 [project.scripts]

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -1,0 +1,52 @@
+"""批量写入示例 Party 和 Contract 数据的脚本"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# 确保 src 目录在导入路径中
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+from contractor.db import init_db, get_session
+from contractor.models import Party, Contract
+
+
+def seed() -> None:
+    """向数据库填充示例的 Party 和 Contract 记录"""
+    init_db()
+
+    parties = [
+        Party(name="Alpha Corp", country="CN"),
+        Party(name="Beta LLC", country="US"),
+    ]
+
+    with get_session() as session:
+        session.add_all(parties)
+        session.commit()
+
+        contracts = [
+            Contract(
+                title="Alpha Master Agreement",
+                party_id=parties[0].id,
+                currency="CNY",
+                amount_minor=100_00,
+                status_history=["draft"],
+                currency_rate=1.0,
+            ),
+            Contract(
+                title="Beta Service Contract",
+                party_id=parties[1].id,
+                currency="USD",
+                amount_minor=200_00,
+                status_history=["draft"],
+                currency_rate=7.0,
+            ),
+        ]
+        session.add_all(contracts)
+        session.commit()
+
+
+if __name__ == "__main__":
+    seed()

--- a/src/contractor/models.py
+++ b/src/contractor/models.py
@@ -1,6 +1,8 @@
+"""定义 Party、Contract 与 ContractFile 数据模型"""
 
 from datetime import datetime, date
 from typing import Optional, List
+from sqlalchemy import Column, JSON
 from sqlmodel import SQLModel, Field, Relationship
 
 class Party(SQLModel, table=True):
@@ -14,12 +16,14 @@ class Contract(SQLModel, table=True):
     title: str
     party_id: int = Field(foreign_key="party.id")
     currency: str = "CNY"
-    amount_minor: int = 0  # store as minor units (e.g., cents)
+    amount_minor: int = 0  # 以最小货币单位存储（例如分）
     version: str = "0.1.0"
     template_name: str = "basic_zh"
     created_at: datetime = Field(default_factory=datetime.utcnow)
     effective_date: Optional[date] = None
     status: str = "draft"
+    status_history: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    currency_rate: float = 1.0
 
     party: Party = Relationship(back_populates="contracts")
     files: List["ContractFile"] = Relationship(back_populates="contract")
@@ -27,7 +31,7 @@ class Contract(SQLModel, table=True):
 class ContractFile(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     contract_id: int = Field(foreign_key="contract.id")
-    kind: str  # "tex" | "pdf" | "docx"
+    kind: str  # 文件类型: "tex" | "pdf" | "docx"
     path: str
     created_at: datetime = Field(default_factory=datetime.utcnow)
 


### PR DESCRIPTION
## Summary
- add `status_history` and `currency_rate` to `Contract`
- introduce Alembic with initial migration and config
- provide `seed_data.py` for sample Party and Contract entries
- translate inline comments and add file header notes in Chinese

## Testing
- `pip install alembic` *(fails: Could not find a version that satisfies the requirement alembic)*
- `pip install sqlmodel` *(fails: Could not find a version that satisfies the requirement sqlmodel)*
- `python scripts/seed_data.py` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b00361683883288702ab4cc851069d