### PR TITLE
Add English contract template and HTML conversion

### DIFF
--- a/src/contractor/services/converter.py
+++ b/src/contractor/services/converter.py
@@ -1,17 +1,43 @@
+"""转换服务：利用 Pandoc 将 LaTeX 文件转换为其他格式"""
 
 import subprocess
 from pathlib import Path
 from ..utils.paths import PANDOC_DIR
 
+
 def tex_to_docx(tex_path: Path, reference_docx: Path | None = None) -> Path | None:
+    """将 tex 文件转换为 docx，可选引用模板"""
+    # 构造输出 docx 路径
     docx_path = tex_path.with_suffix(".docx")
+    # 组装 Pandoc 基本命令
     cmd = ["pandoc", str(tex_path), "-o", str(docx_path)]
+    # 使用传入或默认的参考文档以保持样式
     ref = reference_docx if reference_docx and reference_docx.exists() else (PANDOC_DIR / "docx-reference.docx")
     if ref.exists():
         cmd.extend(["--reference-doc", str(ref)])
     try:
+        # 调用 Pandoc 执行转换
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        # 如果生成成功则返回路径
         return docx_path if docx_path.exists() else None
     except Exception as e:
+        # 捕获异常并给出警告
+        print(f"[WARN] Pandoc conversion failed: {e}")
+        return None
+
+
+def tex_to_html(tex_path: Path) -> Path | None:
+    """将 tex 文件转换为 html"""
+    # 构造输出 html 路径
+    html_path = tex_path.with_suffix(".html")
+    # 组装 Pandoc 命令并启用独立模式
+    cmd = ["pandoc", str(tex_path), "-s", "-o", str(html_path)]
+    try:
+        # 执行转换
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        # 返回生成的 html 文件路径
+        return html_path if html_path.exists() else None
+    except Exception as e:
+        # 捕获异常并给出警告
         print(f"[WARN] Pandoc conversion failed: {e}")
         return None

--- a/src/contractor/services/templates.py
+++ b/src/contractor/services/templates.py
@@ -1,16 +1,28 @@
+"""模板渲染服务：加载并渲染合同模板"""
 
 from pathlib import Path
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader, select_autoescape, DebugUndefined
 from ..utils.paths import TEMPLATE_DIR
 
+# 初始化 Jinja2 环境，设置加载器与自动转义
 _env = Environment(
     loader=FileSystemLoader(str(TEMPLATE_DIR)),
-    autoescape=select_autoescape(enabled_extensions=("tex", "j2",))
+    autoescape=select_autoescape(enabled_extensions=("tex", "j2",)),
+    undefined=DebugUndefined,
 )
 
+
 def render_template(template_file: str, context: dict) -> str:
+    """渲染指定模板文件"""
+    # 获取模板并渲染上下文
     template = _env.get_template(template_file)
     return template.render(**context)
 
+
 def available_templates() -> list[str]:
-    return [p.name for p in Path(TEMPLATE_DIR).glob("*.j2")]
+    """列出可用的合同模板"""
+    # 搜索符合命名规则的模板文件
+    files = Path(TEMPLATE_DIR).glob("contract_*.tex.j2")
+    return sorted(
+        p.name.removeprefix("contract_").removesuffix(".tex.j2") for p in files
+    )

--- a/templates/latex/contract_basic_en.tex.j2
+++ b/templates/latex/contract_basic_en.tex.j2
@@ -1,0 +1,46 @@
+% 英文版基础合同模板
+{% extends "base.tex" %}
+{% block body %}
+
+{% set amt_minor = (amount.value * 100)|int -%} % 计算金额的最小单位
+{% set money_num = money_str(amt_minor, amount.currency, "en_US") -%} % 格式化货币字符串
+
+% 各方信息
+\section*{Parties}
+Party (Buyer): {{ party.name }} ({{ party.country or "US" }})\\
+Counterparty (Seller): {{ counterparty.name }} ({{ counterparty.country or "US" }})\\[0.5em]
+
+% 金额与货币
+\section*{Amount and Currency}
+The contract value is: \textbf{ {{ money_num }} }.
+
+% 工作范围
+\section*{Scope of Work}
+{{ scope }}
+
+% 付款条款
+\section*{Payment Terms}
+{{ payment_terms }}
+
+% 交付与验收
+\section*{Delivery and Acceptance}
+{{ delivery_terms }}
+
+% 知识产权与保密
+\section*{Intellectual Property \& Confidentiality}
+{{ ipr_confidentiality }}
+
+% 争议解决
+\section*{Dispute Resolution}
+{{ dispute_resolution }}
+
+% 其他条款
+\section*{Other Terms}
+{{ others }}
+
+% 签署区
+\section*{Signatures}
+Party Rep: \underline{\hspace{8em}} \quad Date: \underline{\hspace{6em}} \\
+Counterparty Rep: \underline{\hspace{8em}} \quad Date: \underline{\hspace{6em}} \\
+
+{% endblock %}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,47 @@
+# 测试模板渲染及默认值行为
+from contractor.services.templates import render_template, available_templates
+
+
+def fake_money_str(amount_minor: int, code: str, locale: str) -> str:
+    """模拟货币格式化函数"""
+    return f"{amount_minor/100:.2f} {code}"
+
+
+# 构造基础上下文字典
+base_context = {
+    "title": "Sample Contract",
+    "version": "0.1",
+    "document_id": "doc1",
+    "party": {"name": "Alice"},
+    "counterparty": {"name": "Bob"},
+    "amount": {"value": 1000, "currency": "USD"},
+    "money_str": fake_money_str,
+    "payment_terms": "Net 30",
+    "delivery_terms": "Email",
+    "ipr_confidentiality": "NDA",
+    "dispute_resolution": "Law",
+    "others": "None",
+    "scope": "Consulting",
+}
+
+
+def test_available_templates_has_english_template():
+    """验证英文模板可被发现"""
+    assert "basic_en" in available_templates()
+
+
+def test_missing_country_defaults():
+    """缺失国家信息时应使用默认值"""
+    ctx = base_context.copy()
+    rendered = render_template("contract_basic_en.tex.j2", ctx)
+    assert "Alice (US)" in rendered
+    assert "Bob (US)" in rendered
+
+
+def test_missing_variable_placeholder():
+    """缺失字段应提示占位符"""
+    ctx = base_context.copy()
+    ctx.pop("scope")
+    rendered = render_template("contract_basic_en.tex.j2", ctx)
+    assert "Undefined" in rendered
+    assert "scope" in rendered


### PR DESCRIPTION
## Summary
- add English LaTeX contract template and expose it via template listing
- enable tex→html conversion through pandoc
- add template rendering tests covering default fallback and missing variable placeholders
- document files with Chinese comments

## Testing
- `PYTHONPATH=src pytest tests/test_templates.py -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement jinja2)*


------
https://chatgpt.com/codex/tasks/task_e_68b00a538f64832889e0a3ad81e8910f