### PR TITLE
Add CLI and template tests with CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# CI 工作流配置文件：在推送和 PR 时运行检查
+
+on:
+  # 当推送到 main 分支或发起 PR 时触发
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # 检出仓库代码
+      - uses: actions/checkout@v4
+      # 设置 Python 环境
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      # 安装运行与开发依赖
+      - name: Install dependencies
+        run: |
+          pip install .[runtime,dev] build
+      # 执行代码静态检查
+      - name: Lint
+        run: ruff src tests
+      # 运行测试并收集覆盖率
+      - name: Test
+        run: coverage run -m pytest
+      # 输出覆盖率报告
+      - name: Coverage report
+        run: coverage report
+      # 构建发行包
+      - name: Build artifacts
+        run: python -m build
+      # 上传构建产物
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,12 @@
 # 项目构建与依赖配置文件
 # ------------------------------
 
+# 构建系统配置
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# 项目信息
 [project]
 name = "contractor"
 version = "0.1.0"
@@ -18,6 +20,7 @@ authors = [{name = "You"}]
 # 核心包不包含固定运行依赖，使用可选的 "runtime" 扩展保持最小安装
 dependencies = []
 
+# 可选依赖分组
 [project.optional-dependencies]
 # 运行应用所需依赖
 runtime = [
@@ -45,10 +48,32 @@ dev = [
   "pytest>=8.2.2",
   "ruff>=0.6.9",
   "alembic>=1.13.1",
+  "coverage[toml]>=7.5.0",
 ]
 
+# 控制台脚本入口
 [project.scripts]
 contractor = "contractor.cli:app"
 
+# hatch 构建配置
 [tool.hatch.build.targets.wheel]
 packages = ["src/contractor"]
+
+# pytest 配置
+[tool.pytest.ini_options]
+addopts = ["-q"]
+testpaths = ["tests"]
+
+# coverage 运行配置
+[tool.coverage.run]
+branch = true
+source = ["src/contractor"]
+
+# coverage 报告配置
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
+# hatch 环境脚本：执行测试
+[tool.hatch.envs.default.scripts]
+test = "coverage run -m pytest"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+"""CLI 命令测试文件，验证应用的命令行接口。"""
+
+from typer.testing import CliRunner
+from contractor.cli import app
+
+
+def test_template_list_outputs_known_template():
+    """模板列表命令应输出已知模板名"""
+    # 创建 Typer 的 CLI 运行器
+    runner = CliRunner()
+    # 调用 template-list 命令并获取输出
+    result = runner.invoke(app, ["template-list"])
+    # 验证命令执行成功并包含指定模板
+    assert result.exit_code == 0
+    assert "basic_en" in result.stdout

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,4 +1,5 @@
-# 测试模板渲染及默认值行为
+"""测试模板渲染与默认值逻辑。"""
+
 from contractor.services.templates import render_template, available_templates
 
 
@@ -27,21 +28,42 @@ base_context = {
 
 def test_available_templates_has_english_template():
     """验证英文模板可被发现"""
+    # 调用模板列表函数并检查是否存在英文模板
     assert "basic_en" in available_templates()
 
 
 def test_missing_country_defaults():
     """缺失国家信息时应使用默认值"""
+    # 复制基础上下文并渲染模板
     ctx = base_context.copy()
     rendered = render_template("contract_basic_en.tex.j2", ctx)
+    # 验证渲染结果中使用默认国家代码
     assert "Alice (US)" in rendered
     assert "Bob (US)" in rendered
 
 
 def test_missing_variable_placeholder():
     """缺失字段应提示占位符"""
+    # 删除上下文中的关键字段以模拟缺失
     ctx = base_context.copy()
     ctx.pop("scope")
+    # 渲染模板并检查占位符提示
     rendered = render_template("contract_basic_en.tex.j2", ctx)
     assert "Undefined" in rendered
     assert "scope" in rendered
+
+from contractor.services.render import render_tex
+
+
+def test_render_tex_writes_file(tmp_path):
+    """渲染 LaTeX 模板并写出包含合同信息的文件"""
+    # 复制上下文并指定文档编号
+    ctx = base_context.copy()
+    ctx["document_id"] = "demo"
+    # 调用 render_tex 生成 TeX 文件
+    tex_path = render_tex("contract_basic_en.tex.j2", ctx, tmp_path)
+    # 读取生成的文件并验证内容
+    content = tex_path.read_text(encoding="utf-8")
+    assert tex_path.exists()
+    assert "Sample Contract" in content
+    assert "Alice (US)" in content


### PR DESCRIPTION
## Summary
- add tests for CLI template list command and LaTeX rendering
- configure pytest, coverage, and hatch test script
- setup CI workflow to lint, test, and build packages
- add Chinese comments to configuration and test files

## Testing
- `pip install .[runtime,dev]` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `coverage run -m pytest` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer'; 'contractor')*


------
https://chatgpt.com/codex/tasks/task_e_68b010822b988328b4b7b1b5ba14814a